### PR TITLE
Small fixup in the docs

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -165,7 +165,7 @@ REX-Ray currently supports the following container platforms:
 
 | Platform       | Use                                                               |
 |:---------------|:------------------------------------------------------------------|
-| Docker         | [Volume Driver Plugin](./user-guide/schedulers/dockermd)          |
+| Docker         | [Volume Driver Plugin](./user-guide/schedulers/docker.md)         |
 | Mesos          | [Volume Driver Isolator module](./user-guide/schedulers/mesos.md) |
 | Mesos + Docker | [Volume Driver Plugin](./user-guide/schedulers/mesos.md)          |
 


### PR DESCRIPTION
This fixes a hyperlink on the main documentation page.